### PR TITLE
feat: allow option to pass user specified SSL version to use during communication

### DIFF
--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -99,6 +99,7 @@ module OpenURI
     :open_timeout => true,
     :ssl_ca_cert => nil,
     :ssl_verify_mode => nil,
+    :ssl_version => nil,
     :ftp_active_mode => false,
     :redirect => true,
     :encoding => nil,
@@ -298,6 +299,8 @@ module OpenURI
       require 'net/https'
       http.use_ssl = true
       http.verify_mode = options[:ssl_verify_mode] || OpenSSL::SSL::VERIFY_PEER
+      http.ssl_version = options[:ssl_version] if options[:ssl_version] && 
+                                    OpenSSL::SSL::SSLContext::METHODS.include?(options[:ssl_version])
       store = OpenSSL::X509::Store.new
       if options[:ssl_ca_cert]
         Array(options[:ssl_ca_cert]).each do |cert|

--- a/test/open-uri/test_ssl.rb
+++ b/test/open-uri/test_ssl.rb
@@ -92,6 +92,26 @@ class TestOpenURISSL
     }
   end
 
+  def test_validation_ssl_version
+    with_https {|srv, dr, url|
+      setup_validation(srv, dr)
+      URI.open("#{url}/data", :ssl_verify_mode => OpenSSL::SSL::VERIFY_NONE, :ssl_version => :TLSv1_2) {|f|
+        assert_equal("200", f.status[0])
+        assert_equal("ddd", f.read)
+      }
+    }
+  end
+
+  def test_validate_bad_ssl_version_silently
+    with_https {|srv, dr, url|
+      setup_validation(srv, dr)
+      URI.open("#{url}/data", :ssl_verify_mode => OpenSSL::SSL::VERIFY_NONE, :ssl_version => :TLS_no_such_version) {|f|
+        assert_equal("200", f.status[0])
+        assert_equal("ddd", f.read)
+      }
+    }
+  end
+
   def test_validation_failure
     unless /mswin|mingw/ =~ RUBY_PLATFORM
       # on Windows, Errno::ECONNRESET will be raised, and it'll be eaten by
@@ -104,16 +124,6 @@ class TestOpenURISSL
     with_https(log_tester) {|srv, dr, url, server_thread, server_log|
       setup_validation(srv, dr)
       assert_raise(OpenSSL::SSL::SSLError) { URI.open("#{url}/data") {} }
-    }
-  end
-
-  def test_validation_ssl_version
-    with_https {|srv, dr, url|
-      setup_validation(srv, dr)
-      URI.open("#{url}/data", :ssl_verify_mode => OpenSSL::SSL::VERIFY_NONE, :ssl_version => :TLSv1_2) {|f|
-        assert_equal("200", f.status[0])
-        assert_equal("ddd", f.read)
-      }
     }
   end
 

--- a/test/open-uri/test_ssl.rb
+++ b/test/open-uri/test_ssl.rb
@@ -107,6 +107,16 @@ class TestOpenURISSL
     }
   end
 
+  def test_validation_ssl_version
+    with_https {|srv, dr, url|
+      setup_validation(srv, dr)
+      URI.open("#{url}/data", :ssl_verify_mode => OpenSSL::SSL::VERIFY_NONE, :ssl_version => :TLSv1_2) {|f|
+        assert_equal("200", f.status[0])
+        assert_equal("ddd", f.read)
+      }
+    }
+  end
+
   def with_https_proxy(proxy_log_tester=lambda {|proxy_log, proxy_access_log| assert_equal([], proxy_log) })
     proxy_log = []
     proxy_logger = WEBrick::Log.new(proxy_log, WEBrick::BasicLog::WARN)


### PR DESCRIPTION
Current implementation do not give option to select a specific SSL version to use during communication. Sometime, servers have requirement of a specific SSL version to use and it rejects connection initated by open-uri.

Added an optional option called ssl_version when correctly specified as one of the values returned by this method OpenSSL::SSL::SSLContext::METHODS, open method uses this ssl version to establish connection.