### PR TITLE
Avoid busting the global constant cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+Gemfile.lock

--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -410,6 +410,13 @@ module OpenURI
     end
   end
 
+  # :stopdoc:
+  RE_LWS = /[\r\n\t ]+/n
+  RE_TOKEN = %r{[^\x00- ()<>@,;:\\"/\[\]?={}\x7f]+}n
+  RE_QUOTED_STRING = %r{"(?:[\r\n\t !#-\[\]-~\x80-\xff]|\\[\x00-\x7f])*"}n
+  RE_PARAMETERS = %r{(?:;#{RE_LWS}?#{RE_TOKEN}#{RE_LWS}?=#{RE_LWS}?(?:#{RE_TOKEN}|#{RE_QUOTED_STRING})#{RE_LWS}?)*}n
+  # :startdoc:
+
   # Mixin for holding meta-information.
   module Meta
     def Meta.init(obj, src=nil) # :nodoc:
@@ -486,13 +493,6 @@ module OpenURI
         nil
       end
     end
-
-    # :stopdoc:
-    RE_LWS = /[\r\n\t ]+/n
-    RE_TOKEN = %r{[^\x00- ()<>@,;:\\"/\[\]?={}\x7f]+}n
-    RE_QUOTED_STRING = %r{"(?:[\r\n\t !#-\[\]-~\x80-\xff]|\\[\x00-\x7f])*"}n
-    RE_PARAMETERS = %r{(?:;#{RE_LWS}?#{RE_TOKEN}#{RE_LWS}?=#{RE_LWS}?(?:#{RE_TOKEN}|#{RE_QUOTED_STRING})#{RE_LWS}?)*}n
-    # :startdoc:
 
     def content_type_parse # :nodoc:
       vs = @metas['content-type']

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -902,5 +902,13 @@ class TestOpenURI < Test::Unit::TestCase
     }
   end
 
-end
+  def test_meta_init_doesnt_bump_global_constant_state
+    skip "RubyVM.stat not defined" unless defined? RubyVM.stat
 
+    OpenURI::Meta.init(Object.new) # prewarm
+
+    before = RubyVM.stat(:global_constant_state)
+    OpenURI::Meta.init(Object.new)
+    assert_equal 0, RubyVM.stat(:global_constant_state) - before
+  end
+end


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/18589

`Object#extend(mod)` bump the global constant cache if the module has constants of its own.

So by moving these constants outside of `Meta` we avoid bumping the cache.

cc @hsbt 