### PR TITLE
Support 308 status redirect

### DIFF
--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -356,7 +356,8 @@ module OpenURI
     when Net::HTTPMovedPermanently, # 301
          Net::HTTPFound, # 302
          Net::HTTPSeeOther, # 303
-         Net::HTTPTemporaryRedirect # 307
+         Net::HTTPTemporaryRedirect, # 307
+         Net::HTTPPermanentRedirect # 308
       begin
         loc_uri = URI.parse(resp['location'])
       rescue URI::InvalidURIError


### PR DESCRIPTION
The [`308 Permanent Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308) status is also a valid redirect response, so this PR adds support for it.

See https://github.com/janko/down/issues/72 for some real-world examples.
