### PR TITLE
Add :max_redirects option

### DIFF
--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -104,7 +104,7 @@ module OpenURI
     :ftp_active_mode => false,
     :redirect => true,
     :encoding => nil,
-    :max_redirects => nil,
+    :max_redirects => 64,
   }
 
   def OpenURI.check_options(options) # :nodoc:
@@ -236,7 +236,7 @@ module OpenURI
         uri = redirect
         raise "HTTP redirection loop: #{uri}" if uri_set.include? uri.to_s
         uri_set[uri.to_s] = true
-        raise "Too many redirects" if max_redirects && uri_set.size > max_redirects
+        raise TooManyRedirects.new("Too many redirects", buf.io) if max_redirects && uri_set.size > max_redirects
       else
         break
       end
@@ -389,6 +389,9 @@ module OpenURI
       @uri = uri
     end
     attr_reader :uri
+  end
+
+  class TooManyRedirects < HTTPError
   end
 
   class Buffer # :nodoc: all

--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -104,6 +104,7 @@ module OpenURI
     :ftp_active_mode => false,
     :redirect => true,
     :encoding => nil,
+    :max_redirects => nil,
   }
 
   def OpenURI.check_options(options) # :nodoc:
@@ -207,6 +208,7 @@ module OpenURI
     end
 
     uri_set = {}
+    max_redirects = options[:max_redirects]
     buf = nil
     while true
       redirect = catch(:open_uri_redirect) {
@@ -234,6 +236,7 @@ module OpenURI
         uri = redirect
         raise "HTTP redirection loop: #{uri}" if uri_set.include? uri.to_s
         uri_set[uri.to_s] = true
+        raise "Too many redirects" if max_redirects && uri_set.size > max_redirects
       else
         break
       end

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -545,6 +545,25 @@ class TestOpenURI < Test::Unit::TestCase
     }
   end
 
+  def test_max_redirects_success
+    with_http {|srv, dr, url|
+      srv.mount_proc("/r1/") {|req, res| res.status = 301; res["location"] = "#{url}/r2"; res.body = "r1" }
+      srv.mount_proc("/r2/") {|req, res| res.status = 301; res["location"] = "#{url}/r3"; res.body = "r2" }
+      srv.mount_proc("/r3/") {|req, res| res.body = "r3" }
+      URI.open("#{url}/r1/", max_redirects: 2) { |f| assert_equal("r3", f.read) }
+    }
+  end
+
+  def test_max_redirects_too_many
+    with_http {|srv, dr, url|
+      srv.mount_proc("/r1/") {|req, res| res.status = 301; res["location"] = "#{url}/r2"; res.body = "r1" }
+      srv.mount_proc("/r2/") {|req, res| res.status = 301; res["location"] = "#{url}/r3"; res.body = "r2" }
+      srv.mount_proc("/r3/") {|req, res| res.body = "r3" }
+      exc = assert_raise(RuntimeError) { URI.open("#{url}/r1/", max_redirects: 1) {} }
+      assert_equal("Too many redirects", exc.message)
+    }
+  end
+
   def test_userinfo
     assert_raise(ArgumentError) { URI.open("http://user:pass@127.0.0.1/") {} }
   end

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -559,7 +559,7 @@ class TestOpenURI < Test::Unit::TestCase
       srv.mount_proc("/r1/") {|req, res| res.status = 301; res["location"] = "#{url}/r2"; res.body = "r1" }
       srv.mount_proc("/r2/") {|req, res| res.status = 301; res["location"] = "#{url}/r3"; res.body = "r2" }
       srv.mount_proc("/r3/") {|req, res| res.body = "r3" }
-      exc = assert_raise(RuntimeError) { URI.open("#{url}/r1/", max_redirects: 1) {} }
+      exc = assert_raise(OpenURI::TooManyRedirects) { URI.open("#{url}/r1/", max_redirects: 1) {} }
       assert_equal("Too many redirects", exc.message)
     }
   end


### PR DESCRIPTION
Adds an option to limit the number of redirects.

```ruby
URI.open(url, max_redirects: 2)
```

There's no limit by default for backward compatibility, but I think it'd be good for include one in a future version.