### PR TITLE
Add `net-ftp` gem that has been bundled gem since Ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "net-ftp"
 gem "rake"
 gem "test-unit"
 gem "test-unit-ruby-core"


### PR DESCRIPTION
This pull request adds `net-ftp` gem that has been bundled gem since Ruby 3.1.

- This commit addresses the warning below
```ruby
$ bundle exec rake test
/home/yahonda/src/github.com/ruby/open-uri/test/open-uri/test_open-uri.rb:739: warning: net/ftp was loaded from the standard library, but is not part of the default gems since Ruby 3.1.0. Add net-ftp to your Gemfile or gemspec.
```
- Ruby 3.1.0 Released
https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/
> The following default gems are now bundled gems. You need to add the following libraries to Gemfile under the bundler environment.
net-ftp 0.1.3