### PR TITLE
Enhance security by removing Authorization header on HTTP redirects

### DIFF
--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -769,6 +769,38 @@ module OpenURI
     #
     #  Number of HTTP redirects allowed before OpenURI::TooManyRedirects is raised.
     #  The default is 64.
+    #
+    # [:request_specific_fields]
+    #  Synopsis:
+    #    :request_specific_fields => {}
+    #    :request_specific_fields => lambda {|url| ...}
+    #
+    #  :request_specific_fields option allows specifying custom header fields that
+    #  are sent with the HTTP request. It can be passed as a Hash or a Proc that
+    #  gets evaluated on each request and returns a Hash of header fields.
+    #
+    #  If a Hash is provided, it specifies the headers only for the initial
+    #  request and these headers will not be sent on redirects.
+    #
+    #  If a Proc is provided, it will be executed for each request including
+    #  redirects, allowing dynamic header customization based on the request URL.
+    #  It is important that the Proc returns a Hash. And this Hash specifies the
+    #  headers to be sent with the request.
+    #
+    #  For Example with Hash
+    #    URI.open("http://...",
+    #             request_specific_fields: {"Authorization" => "token dummy"}) {|f| ... }
+    #
+    #  For Example with Proc:
+    #    URI.open("http://...",
+    #             request_specific_fields: lambda { |uri|
+    #               if uri.host == "example.com"
+    #                 {"Authorization" => "token dummy"}
+    #               else
+    #                 {}
+    #               end
+    #             }) {|f| ... }
+    #
     def open(*rest, &block)
       OpenURI.open_uri(self, *rest, &block)
     end

--- a/lib/open-uri.rb
+++ b/lib/open-uri.rb
@@ -151,7 +151,7 @@ module OpenURI
     end
     if options.has_key? :request_specific_fields
       if !(options[:request_specific_fields].is_a?(Hash) || options[:request_specific_fields].is_a?(Proc))
-        raise ArgumentError, "Invalid request_specific_fields' format: #{options[:request_specific_fields]}"
+        raise ArgumentError, "Invalid request_specific_fields option: #{options[:request_specific_fields].inspect}"
       end
     end
     unless mode == nil ||

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -337,6 +337,66 @@ class TestOpenURI < Test::Unit::TestCase
     }
   end
 
+  def test_redirect_without_request_specific_fields_hash
+    authorization_header = nil
+    redirected_authorization_header = nil
+    with_http {|srv, url|
+      srv.mount_proc("/r1/", lambda {|req, res| res.status = 301; res["location"] = "#{url}/r2"; authorization_header = req["Authorization"]; } )
+      srv.mount_proc("/r2/", lambda {|req, res| redirected_authorization_header = req["Authorization"]; } )
+      URI.open("#{url}/r1/", "Authorization" => "dummy_token") {|f|
+        assert_equal("dummy_token", authorization_header)
+        assert_equal("#{url}/r2", f.base_uri.to_s)
+        assert_equal("dummy_token", redirected_authorization_header)
+      }
+    }
+  end
+
+  def test_redirect_with_request_specific_fields_hash
+    authorization_header = nil
+    redirected_authorization_header = "exposed_dummy_token"
+    with_http {|srv, url|
+      srv.mount_proc("/r1/", lambda {|req, res| res.status = 301; res["location"] = "#{url}/r2"; authorization_header = req["Authorization"]; } )
+      srv.mount_proc("/r2/", lambda {|req, res| redirected_authorization_header = req["Authorization"]; } )
+      URI.open("#{url}/r1/", request_specific_fields: {"Authorization" => "dummy_token"}) {|f|
+        assert_equal("dummy_token", authorization_header)
+        assert_equal("#{url}/r2", f.base_uri.to_s)
+        assert_equal(nil, redirected_authorization_header)
+      }
+    }
+  end
+
+  def test_redirect_with_request_specific_fields_proc
+    authorization_header = nil
+    redirected_authorization_header = nil
+
+    modify_authorization_header = Proc.new do |uri|
+      authorization_token = if uri.to_s.include?("/r1")
+                              "dummy_token"
+                            else
+                              "masked_dummy_token"
+                            end
+      { "Authorization" => authorization_token }
+    end
+
+    with_http {|srv, url|
+      srv.mount_proc("/r1/", lambda {|req, res| res.status = 301; res["location"] = "#{url}/r2"; authorization_header = req["Authorization"] } )
+      srv.mount_proc("/r2/", lambda {|req, res| redirected_authorization_header = req["Authorization"]; } )
+      URI.open("#{url}/r1/", request_specific_fields: modify_authorization_header) {|f|
+        assert_equal("dummy_token", authorization_header)
+        assert_equal("#{url}/r2", f.base_uri.to_s)
+        assert_equal("masked_dummy_token", redirected_authorization_header)
+      }
+    }
+  end
+
+  def test_redirect_with_invalid_request_specific_fields_format
+    with_http {|srv, url|
+      srv.mount_proc("/r1/", lambda {|req, res| res.body = "r1" } )
+      exc = assert_raise(ArgumentError) { URI.open("#{url}/r1/", request_specific_fields: "dummy_token") {} }
+      assert_equal("Invalid request_specific_fields' format: dummy_token", exc.message)
+    }
+  end
+
   def test_max_redirects_success
     with_http {|srv, url|
       srv.mount_proc("/r1/", lambda {|req, res| res.status = 301; res["location"] = "#{url}/r2"; res.body = "r1" } )

--- a/test/open-uri/test_open-uri.rb
+++ b/test/open-uri/test_open-uri.rb
@@ -393,7 +393,7 @@ class TestOpenURI < Test::Unit::TestCase
     with_http {|srv, url|
       srv.mount_proc("/r1/", lambda {|req, res| res.body = "r1" } )
       exc = assert_raise(ArgumentError) { URI.open("#{url}/r1/", request_specific_fields: "dummy_token") {} }
-      assert_equal("Invalid request_specific_fields' format: dummy_token", exc.message)
+      assert_equal('Invalid request_specific_fields option: "dummy_token"', exc.message)
     }
   end
 


### PR DESCRIPTION
When redirects occur, the Authorization header containing authorization information is transferred to the redirect destination host. This can expose sensitive credentials to unintended hosts, posing a security risk.

I will introduce a case where the Authorization header is unintentionally transferred during redirection.

## Case

The issue occurs when downloading GitHub Actions Artifacts using the GitHub REST API.

* https://docs.github.com/ja/rest/actions/artifacts#download-an-artifact

The process is as follows.

1. Authorize using the Authorization header.
2. Redirect to a URL containing a Shared Access Signature (SAS) for downloading the artifact.
3. Download the artifact.

During the redirect in step 2, the Authorization header from step 1 is retained and transferred to the redirect destination.
This results in an authorization error due to the redirection destination misinterpreting the Authorization header content as the SAS.

### Reproduce code

Here is a Ruby code example that demonstrates the problem, resulting in a 403 error because the Authorization header does not match the expected signature format.

```ruby
require 'open-uri'

uri = ENV['ARTIFACT_URL']
access_token = ENV['GITHUB_ACCESS_TOKEN']

URI(uri).open("Authorization" => "token #{access_token}")
```

```
$ ARTIFACT_URL="https://api.github.com/repos/:owner/sandbox-github-actions-artifacts-v4/actions/artifacts/:artifact_id/zip" \
 GITHUB_ACCESS_TOKEN="your_access_token" \
 ruby download_artifact.rb

/home/kodama/.rbenv/versions/3.3.2/lib/ruby/3.3.0/open-uri.rb:376:in `open_http': 403 Server failed to authenticate the request. Make sure the value of the Authorization header is formed correctly, including the signature. (OpenURI::HTTPError)
```

### Workaround

When redirecting without transferring the Authorization header content, the download succeeds without errors.
This means the Authorization header is retained during redirects.

```ruby
require 'open-uri'

uri = ENV['ARTIFACT_URL']
access_token = ENV['GITHUB_ACCESS_TOKEN']

headers = {
 "Authorization" => "token #{access_token}",
 redirect: false
}

loop do
 begin
   URI.open(uri, headers)
   break
 rescue OpenURI::HTTPRedirect => redirect
   headers.delete("Authorization")
   pp uri = redirect.uri
 end
end
```

```
$ ARTIFACT_URL="https://api.github.com/repos/:owner/sandbox-github-actions-artifacts-v4/actions/artifacts/:artifact_id/zip" \
 GITHUB_ACCESS_TOKEN="your_access_token" \
 ruby download_artifact.rb

#<URI::HTTPS https://productionresultssa11.blob.core.windows.net/actions-results/xxx>
```

## Expected Improvement

We aim to improve security by removing the Authorization header during redirects if necessary, preventing its inadvertent transfer to the redirect destination host.

The Fetch specification recommends removing the Authorization header on cross-origin redirects.

* https://fetch.spec.whatwg.org/#http-redirect-fetch

### Supplemental Information

Examples of software or specifications that do not transfer the Authorization header on redirect:

#### Curl

Curl does not transfer the Authorization header on redirects and this issue is reported as a CVE.

* https://github.com/curl/curl/commit/af32cd3859336ab963591ca0df9b1e33a7ee066b
* https://curl.se/docs/CVE-2018-1000007.html

#### GO

Go removes the Authorization header when redirecting to different hosts but retains it if the redirect is to the same host.

* https://github.com/golang/go/blob/b3040679ad0eccaaadb825ed8c0704086ecc23eb/src/net/http/client.go#L41-L49
* https://go-review.googlesource.com/c/go/+/28930

## Proposed Solutions

To address the `Expected Improvement` mentioned above and to ensure future flexibility for handling headers beyond just the Authorization header, we propose introducing a customizable solution that allows users to define their own header-handling rules. This approach ensures that users can manage which headers are retained or removed during redirects, providing a flexible and secure implementation.

To provide this customization feature, we introduce the `request_specific_fields` option. This option offers two methods for handling headers as follows:

- Specify headers only for the initial request.
- Specify headers dynamically for each request during the request lifecycle.

### Specify headers for the initial request (Using a `Hash`)

Users can specify request specific headers for the initial request via a `Hash`.
These headers will only be applied to the first request and automatically removed on redirects.

```ruby
URI.open("http://...", request_specific_fields: { "Authorization" => "token dummy" }) {|f| ... }
```

### Specify headers for each request (Using a `Proc`)

For more dynamic control, users can define a `Proc` that generates headers based on the URL of each request.
The Proc is evaluated for every request, including those made during redirects, allowing for flexible header management throughout the request lifecycle.

```ruby
URI.open("http://...", request_specific_fields: lambda { |uri|
  if uri.host == "example.com"
    { "Authorization" => "token dummy" }
  else
    { "Authorization" => nil }
  end
}) {|f| ... }
```

By implementing the `request_specific_fields` option in this way, we provide flexibility without hardcoding sensitive fields like the "Authorization" header. Users maintain full control over which headers are sent with each request, allowing them to exclude sensitive headers during redirects if desired. This solution keeps OpenURI secure by design while offering customizable behavior when needed.